### PR TITLE
Implement the ability to extract and forward claims up/down stream

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,9 @@ func main() {
 	flagSet.String("claim-authorization", "", "JMESPath (https://jmespath.org/) expression that the claims in the id_token must match in order to be considered valid")
 	flagSet.String("claim-authorizations-file", "", "file to read additional claim-authorizations from, one per line (format is the same as for claim-assertions; first match wins)")
 
+	flagSet.String("claims-fwd-expr", "", "extract a portion of the authenticated user's claim structure to forward up/down stream")
+	flagSet.Bool("pass-claims-fwd", false, "if true, and claims-fwd-expr is also set, will send X-Forwarded-User-Claims in upstream request headers")
+
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")
 	flagSet.String("keycloak-group", "", "restrict login to members of this group.")

--- a/main.go
+++ b/main.go
@@ -61,8 +61,8 @@ func main() {
 	flagSet.String("claim-authorization", "", "JMESPath (https://jmespath.org/) expression that the claims in the id_token must match in order to be considered valid")
 	flagSet.String("claim-authorizations-file", "", "file to read additional claim-authorizations from, one per line (format is the same as for claim-assertions; first match wins)")
 
-	flagSet.String("claims-fwd-expr", "", "extract a portion of the authenticated user's claim structure to forward up/down stream")
-	flagSet.Bool("pass-claims-fwd", false, "if true, and claims-fwd-expr is also set, will send X-Forwarded-User-Claims in upstream request headers")
+	flagSet.String("claims-fwd-query", "", "extract a portion of the authenticated user's claim structure to forward up/down stream")
+	flagSet.Bool("pass-claims-fwd", false, "if true, and claims-fwd-query is also set, will send X-Forwarded-User-Claims in upstream request headers")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -807,7 +807,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 				// Make it obvious if the server sends something that was not anticipated,
 				// since anyone who configured this is likely expecting certain values...
 				p.ErrorPage(rw, 417, "Expectation Failed", "Unable to parse expected response from authentication server")
-				logger.PrintAuthf(session.Email, req, logger.AuthFailure, "User claims did not match expected results: %v", err)
+				logger.PrintAuthf(session.Email, req, logger.AuthError, "User claims did not match expected results: %v", err)
 				return
 			}
 		}
@@ -974,7 +974,7 @@ func (p *OAuthProxy) getAuthenticatedSession(rw http.ResponseWriter, req *http.R
 						if err := session.ExtractForwardedClaims(p.claimsFwdExpr); err != nil {
 							// Make it obvious if the server sends something that was not anticipated,
 							// since anyone who configured this is likely expecting certain values...
-							logger.PrintAuthf(session.Email, req, logger.AuthFailure, "Removing re-validatied session because user claims did not match expected results: %v", err)
+							logger.PrintAuthf(session.Email, req, logger.AuthError, "Removing re-validatied session because user claims did not match expected results: %v", err)
 							session = nil
 							saveSession = false
 							clearSession = true


### PR DESCRIPTION
It is often useful to provide access to the validated claims that authenticated users have (according to the provider of choice). These can be used for a number of different application-specific purposes, including providing extra user information or context (such as role or group assignments, unique IDs, entitlements, etc).

This PR implements a system whereby claims that are exposed via the authentication process can be opaquely exposed to both a consuming client (in the case of a non-http-only cookie) and an upstream server (via an `X-Forwarded-User-Claims`) using a serialized representation.

Further, a [JMESPath](https://jmespath.org) "query expression" is specified using `-claims-fwd-query` or `OAUTH2_PROXY_CLAIMS_FWD_QUERY` and is used to select a subset of the claims that should be forwarded (not all are needed) or in fact remapping some claim values into a more application-friendly representation. Or, the entire claims object can be forwarded if desired using the special `@` query (the JMESPath expression for "this").

Some examples of usage: 

* Select the full claims object: `-claims-fwd-query` `@`
```
X-Forwarded-User-Claims: {"sub":"gandalf123","name":"Gandalf","job":"Wizard"}
```

* Select just the job: `-claims-fwd-query` `job`
```
X-Forwarded-User-Claims: "Wizard"
```

* Select name and job (with different key values for each): `-claims-fwd-query` `{n:name,j:job}`
```
X-Forwarded-User-Claims: {"n":"Gandalf","j":"Wizard"}
```

* Select the id using either the 'userid' field (if present), and fallback to 'sub' field: `-claims-fwd-query` `{id:userid||sub}`
```
X-Forwarded-User-Claims: {"id":"gandalf123","j":"Wizard"}
```

* Selecting a field that doesn't exist: `-claims-fwd-query` `favoriteColor`
```
X-Forwarded-User-Claims: null
```

## How Has This Been Tested?

Tested on Windows using Go 1.14 against Microsoft Identity Server (AADv2 OIDC). There is a unit test to stress these expressions as well.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
